### PR TITLE
make _request_timeout args work as expected; add default timeout

### DIFF
--- a/osisoft/pidevclub/piwebapi/api_client.py
+++ b/osisoft/pidevclub/piwebapi/api_client.py
@@ -136,7 +136,8 @@ class ApiClient(object):
         response_data = self.request(method, url,
                                      query_params=query_params,
                                      headers=header_params,
-                                     body=body)
+                                     body=body,
+                                     timeout=_request_timeout)
 
         return_data = response_data
         if _preload_content:
@@ -321,12 +322,13 @@ class ApiClient(object):
         thread.start()
         return thread
 
-    def request(self, method, url, query_params=None, headers=None, body=None):
+    def request(self, method, url, query_params=None, headers=None, body=None, timeout=None):
 
         return self.rest_client.send_request(url, method,
                                     body=body,
                                     query_params=query_params,
-                                    headers=headers)
+                                    headers=headers,
+                                    timeout=timeout)
 
 
 

--- a/osisoft/pidevclub/piwebapi/rest.py
+++ b/osisoft/pidevclub/piwebapi/rest.py
@@ -45,7 +45,7 @@ class RESTClientObject(object):
         self.verifySsl = verifySsl
 
 
-    def send_request(self, url, method, body, headers=None,query_params=None):
+    def send_request(self, url, method, body, headers=None, query_params=None, timeout=None):
 
         """
         Makes the HTTP request using RESTClient.
@@ -53,20 +53,23 @@ class RESTClientObject(object):
         if query_params:
             url += '?' + urlencode(query_params)
 
+        if timeout is None:
+            timeout = (60, 600) # 1 minute connection timeout; 10 minute response timeout
+
         if method == "GET":
-            response = requests.get(url, auth=self.auth, headers=headers, verify=self.verifySsl)
+            response = requests.get(url, auth=self.auth, headers=headers, verify=self.verifySsl, timeout=timeout)
         elif method == "HEAD":
-            response = requests.head(url, auth=self.auth, headers=headers, verify=self.verifySsl)
+            response = requests.head(url, auth=self.auth, headers=headers, verify=self.verifySsl, timeout=timeout)
         elif method == "OPTIONS":
-            response = requests.options(url, auth=self.auth, headers=headers, verify=self.verifySsl)
+            response = requests.options(url, auth=self.auth, headers=headers, verify=self.verifySsl, timeout=timeout)
         elif method == "POST":
-            response = requests.post(url, json=body, auth=self.auth, headers=headers, verify=self.verifySsl)
+            response = requests.post(url, json=body, auth=self.auth, headers=headers, verify=self.verifySsl, timeout=timeout)
         elif method == "PUT":
-            response = requests.put(url, json=body, auth=self.auth, headers=headers, verify=self.verifySsl)
+            response = requests.put(url, json=body, auth=self.auth, headers=headers, verify=self.verifySsl, timeout=timeout)
         elif method == "PATCH":
-            response = requests.patch(url, json=body, auth=self.auth, headers=headers, verify=self.verifySsl)
+            response = requests.patch(url, json=body, auth=self.auth, headers=headers, verify=self.verifySsl, timeout=timeout)
         elif method == "DELETE":
-            response = requests.delete(url, auth=self.auth, headers=headers, verify=self.verifySsl)
+            response = requests.delete(url, auth=self.auth, headers=headers, verify=self.verifySsl, timeout=timeout)
         else:
             raise ValueError(
                 "http method must be `GET`, `HEAD`, `OPTIONS`,"


### PR DESCRIPTION
My team was intermittently receiving alerts about the following error coming from requests through the PI web API client:
```
HTTPSConnectionPool(host='[redacted], port=443): Max retries exceeded with url: 
/piwebapi/attributes?path=[redacted] (Caused by ConnectTimeoutError(
urllib3.connection.HTTPSConnection object at 0x7fbf482d9a20, 
'Connection to [redacted] timed out. (connect timeout=None)'))
```
I saw that the client's API methods do accept `_request_timeout` arguments, but those arguments are not actually passed through to the request, so they don't do anything. This PR does two things:
1. Fixes the implementation of the `_request_timeout` arg so that it works as intended
2. Adds a default timeout. With no default in place, the timeout depends on the host system, which can cause issues when the application moves between platforms, as happened in my case. 

We have been running this branch in production and our timeout issues are resolved. 